### PR TITLE
Allow Hubble Relay on Master Node

### DIFF
--- a/ansible/playbooks/tasks/cilium.yaml
+++ b/ansible/playbooks/tasks/cilium.yaml
@@ -60,7 +60,7 @@
   kubernetes.core.helm:
     name: cilium
     chart_ref: cilium/cilium
-    chart_version: "1.19.1"
+    chart_version: "1.18.5"
     release_namespace: kube-system
     create_namespace: false
     wait: true


### PR DESCRIPTION
- Added toleration on Cilium helm values for hubble to have hubble relay instance on master too (necessary in order to observe all flows with hubble)
- Kept cilium version 1.18.5 because 1.19.1 is creating connectivity issues with kube-ovn