### PR TITLE
Increase Vmetrics Components Resources

### DIFF
--- a/fleet/victoria-metrics-stack/fleet.yaml
+++ b/fleet/victoria-metrics-stack/fleet.yaml
@@ -492,7 +492,7 @@ helm:
         spec:
           port: "8080"
           selectAllByDefault: true
-          evaluationInterval: 20s
+          evaluationInterval: 30s
           extraArgs:
             http.pathPrefix: "/"
           resources:
@@ -678,7 +678,7 @@ helm:
                 
           port: "8429"
           selectAllByDefault: true
-          scrapeInterval: 10s
+          scrapeInterval: 30s
           externalLabels:
             cluster: "vaclab"
             # For multi-cluster setups it is useful to use "cluster" label to identify the metrics source.
@@ -1064,8 +1064,8 @@ helm:
           spec:
             scheme: "https"
             honorLabels: true
-            interval: "10s"
-            scrapeTimeout: "5s"
+            interval: "30s"
+            scrapeTimeout: "10s"
             tlsConfig:
               insecureSkipVerify: true
               caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt


### PR DESCRIPTION
- Increase vmagent resources (to avoid scrapping bottleneck)
- Increase victoria-metrics operator resources
- Increase node-exporter resources
- Increase vmalert resources
- Set all scrape interval to 30s