### PR TITLE
Keep Waku Metrics and Increase Grafana DS interval

### DIFF
--- a/fleet/victoria-metrics-stack/fleet.yaml
+++ b/fleet/victoria-metrics-stack/fleet.yaml
@@ -678,9 +678,21 @@ helm:
                   regex: 'kube-system|kyverno|homepage|authentik|vaclab-system|cert-manager|cattle-capi-system|cattle-fleet-clusters-system|cattle-fleet-local-system|cattle-fleet-system|cattle-global-data|cattle-impersonation-system|cattle-local-user-passwords|cattle-system|cattle-turtles-system|cattle-ui-plugin-system|cilium-secrets|fleet-default|fleet-local|kube-node-lease|kube-public|local|longhorn-system|policy-reporter|victorialogs|vmetrics'
                   action: drop
               metric_relabel_configs:
+                # Keep libp2p and waku metrics
+                # libp2p: libp2p_peers, libp2p_open_streams, libp2p_network_bytes_total, nim_gc_mem_bytes, libp2p_gossipsub_low_peers_topics, network_bytes_*
+                # waku node: waku_version, waku_node_messages, waku_node_errors
+                # waku peer_manager: waku_peers_dials, waku_peers_errors, waku_connected_peers, waku_connected_peers_per_shard, waku_connected_peers_per_agent, waku_streams_peers, waku_peer_store_size, waku_service_peers, waku_total_unique_peers, waku_lightpush_peers, waku_filter_peers, waku_store_peers, waku_px_peers
+                # waku relay: waku_relay_network_bytes, waku_relay_total_msg_bytes_per_shard, waku_relay_max_msg_bytes_per_shard, waku_relay_avg_msg_bytes_per_shard, waku_msg_validator_signed_outcome
+                # waku store/archive: waku_archive_messages, waku_archive_messages_per_shard, waku_archive_errors, waku_archive_insert_duration_seconds, waku_archive_query_duration_seconds, postgres_payload_size_bytes, waku_store_errors, waku_store_queries, waku_store_time_seconds, waku_relay_fleet_store_msg_size_bytes, waku_relay_fleet_store_msg_count, query_time_secs, query_count
+                # waku filter: waku_filter_errors, waku_filter_requests, waku_filter_subscriptions, waku_filter_request_duration_seconds, waku_filter_handle_message_duration_seconds
+                # waku lightpush: waku_lightpush_v3_errors, waku_lightpush_v3_messages, waku_lightpush_errors, waku_lightpush_messages
+                # waku discovery: waku_dnsdisc_discovered, waku_dnsdisc_errors, waku_discv5_discovered_per_shard, waku_discv5_errors
+                # waku peer_exchange: waku_px_peers_received_unknown, waku_px_errors, waku_px_peers_sent, waku_px_peers_received_total, waku_px_client_errors
+                # waku rate_limit: waku_service_requests_limit, waku_service_requests, waku_service_network_bytes, waku_service_request_handling_duration_seconds
+                # waku rendezvous: rendezvousPeerFoundTotal
                 - source_labels: [__name__]
                   action: keep
-                  regex: '^(libp2p_peers|libp2p_open_streams|libp2p_network_bytes_total|nim_gc_mem_bytes|libp2p_gossipsub_low_peers_topics|network_bytes_in_total_port_60000_total|network_bytes_out_total_port_60000_total)$'
+                  regex: '^(libp2p_peers|libp2p_open_streams|libp2p_network_bytes_total|nim_gc_mem_bytes|libp2p_gossipsub_low_peers_topics|network_bytes_in_total_port_60000_total|network_bytes_out_total_port_60000_total|waku_version|waku_node_messages|waku_node_errors|waku_peers_dials|waku_peers_errors|waku_connected_peers|waku_connected_peers_per_shard|waku_connected_peers_per_agent|waku_streams_peers|waku_peer_store_size|waku_service_peers|waku_total_unique_peers|waku_lightpush_peers|waku_filter_peers|waku_store_peers|waku_px_peers|waku_relay_network_bytes|waku_relay_total_msg_bytes_per_shard|waku_relay_max_msg_bytes_per_shard|waku_relay_avg_msg_bytes_per_shard|waku_msg_validator_signed_outcome|waku_archive_messages|waku_archive_messages_per_shard|waku_archive_errors|waku_archive_insert_duration_seconds|waku_archive_query_duration_seconds|postgres_payload_size_bytes|waku_store_errors|waku_store_queries|waku_store_time_seconds|waku_relay_fleet_store_msg_size_bytes|waku_relay_fleet_store_msg_count|query_time_secs|query_count|waku_filter_errors|waku_filter_requests|waku_filter_subscriptions|waku_filter_request_duration_seconds|waku_filter_handle_message_duration_seconds|waku_lightpush_v3_errors|waku_lightpush_v3_messages|waku_lightpush_errors|waku_lightpush_messages|waku_dnsdisc_discovered|waku_dnsdisc_errors|waku_discv5_discovered_per_shard|waku_discv5_errors|waku_px_peers_received_unknown|waku_px_errors|waku_px_peers_sent|waku_px_peers_received_total|waku_px_client_errors|waku_service_requests_limit|waku_service_requests|waku_service_network_bytes|waku_service_request_handling_duration_seconds|rendezvousPeerFoundTotal)$'
                 
           port: "8429"
           selectAllByDefault: true
@@ -778,11 +790,15 @@ helm:
               type: prometheus
               access: proxy
               isDefault: true
+              jsonData:
+                timeInterval: "30s"
             - name: VictoriaMetrics (DS)
               isDefault: false
               access: proxy
               type: victoriametrics-metrics-datasource
               version: "0.15.1"
+              jsonData:
+                timeInterval: "30s"
               #version: "0.15.1"
         # -- List of alertmanager datasources.
         # VMAlertmanager generated `url` will be added to each datasource in template if alertmanager is enabled
@@ -942,6 +958,7 @@ helm:
                 app.kubernetes.io/name: '{{ include "grafana.name" .Subcharts.grafana }}'
             endpoints:
               - port: '{{ .Values.grafana.service.portName }}'
+                interval: "30s"
 
       defaultScrapeService:
         namespace: kube-system


### PR DESCRIPTION
- Keep some selected waku metrics in libp2p-nodes scrape job
- Increase Grafana Datasource Scrape Interval to 30s (grafana will now wait 30s before querying new data from the data sources)