### PR TITLE
Deploy DST Dashboard and Update HomePage

### DIFF
--- a/fleet/dst-dashboard/backend/backend.yaml
+++ b/fleet/dst-dashboard/backend/backend.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: dst-dashboard-backend
+spec:
+  serviceName: dst-dashboard-backend
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dst-dashboard-backend
+  template:
+    metadata:
+      labels:
+        app: dst-dashboard-backend
+        app.kubernetes.io/name: dst-dashboard-backend
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - metal-01.he-eu-hel1.misc.vacdst
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "monitoring"
+          effect: "PreferNoSchedule"
+      containers:
+      - name: dst-dashboard-backend
+        image: mamoutoudiarra/dst-dashboard-backend:v1.0
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8000
+          name: http
+        env:
+        - name: DST_MONGO_URI
+          valueFrom:
+            secretKeyRef:
+              name: dst-mongo-prod-credentials
+              key: uri
+        - name: DST_JWT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: dst-dashboard-jwt-secret
+              key: secret
+        - name: DST_CONFIG_PATH
+          value: /app/config/config.yaml
+        volumeMounts:
+        - name: config
+          mountPath: /app/config
+          readOnly: true
+        resources:
+          requests:
+            memory: "4Gi"
+            cpu: "4"
+          limits:
+            memory: "16Gi"
+            cpu: "8"
+      volumes:
+      - name: config
+        configMap:
+          name: dst-dashboard-config

--- a/fleet/dst-dashboard/backend/fleet.yaml
+++ b/fleet/dst-dashboard/backend/fleet.yaml
@@ -1,0 +1,3 @@
+defaultNamespace: dst-dashboard
+dependsOn:
+  - name: vaclab-2-fleet-dst-dashboard-mongodb

--- a/fleet/dst-dashboard/config/config.yaml
+++ b/fleet/dst-dashboard/config/config.yaml
@@ -6,6 +6,7 @@ data:
   config.yaml: |
     # DST Explorer Configuration
     # Global datasources - defined once, referenced by all experiments
+    # Do not use to load experiments (deprecated)
 
     datasources:
       - name: victoria-logs

--- a/fleet/dst-dashboard/config/config.yaml
+++ b/fleet/dst-dashboard/config/config.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dst-dashboard-config
+data:
+  config.yaml: |
+    # DST Explorer Configuration
+    # Global datasources - defined once, referenced by all experiments
+
+    datasources:
+      - name: victoria-logs
+        type: VictoriaLogs
+        url: http://vlc-victoria-logs-cluster-vlselect.victorialogs:9471/select/logsql/query
+
+      - name: victoria-metrics
+        type: Prometheus
+        url: http://vmselect-vmks-victoria-metrics-k8s-stack.vmetrics:8481/select/0/prometheus/api/v1/

--- a/fleet/dst-dashboard/config/fleet.yaml
+++ b/fleet/dst-dashboard/config/fleet.yaml
@@ -1,0 +1,1 @@
+defaultNamespace: dst-dashboard

--- a/fleet/dst-dashboard/fleet.yaml
+++ b/fleet/dst-dashboard/fleet.yaml
@@ -1,0 +1,4 @@
+defaultNamespace: dst-dashboard
+dependsOn:
+  - name: vaclab-2-fleet-longhorn
+  - name: vaclab-2-fleet-storage

--- a/fleet/dst-dashboard/frontend/fleet.yaml
+++ b/fleet/dst-dashboard/frontend/fleet.yaml
@@ -1,0 +1,3 @@
+defaultNamespace: dst-dashboard
+dependsOn:
+  - name: vaclab-2-fleet-dst-dashboard-backend

--- a/fleet/dst-dashboard/frontend/frontend.yaml
+++ b/fleet/dst-dashboard/frontend/frontend.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: dst-dashboard-frontend
+spec:
+  serviceName: dst-dashboard-frontend
+  replicas: 2
+  selector:
+    matchLabels:
+      app: dst-dashboard-frontend
+  template:
+    metadata:
+      labels:
+        app: dst-dashboard-frontend
+        app.kubernetes.io/name: dst-dashboard-frontend
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - metal-01.he-eu-hel1.misc.vacdst
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "monitoring"
+          effect: "PreferNoSchedule"
+      containers:
+      - name: frontend
+        image: mamoutoudiarra/dst-dashboard-frontend:v0.5
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 80
+          name: http
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "500m"
+          limits:
+            memory: "2Gi"
+            cpu: "2"

--- a/fleet/dst-dashboard/ingresses/backend.admin.yaml
+++ b/fleet/dst-dashboard/ingresses/backend.admin.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dst-dashboard-backend-admin-token-ingress
+  annotations:
+    traefik.ingress.kubernetes.io/router.middlewares: default-redirect-https@kubernetescrd,default-authentik-forwardauth@kubernetescrd
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  ingressClassName: traefik
+  tls:
+  - hosts:
+    - api.dashboard.lab.vac.dev
+    secretName: dashboard-backend-tls
+  rules:
+  - host: api.dashboard.lab.vac.dev
+    http:
+      paths:
+      - path: /admin/token
+        pathType: Exact
+        backend:
+          service:
+            name: dst-dashboard-backend
+            port:
+              number: 8000

--- a/fleet/dst-dashboard/ingresses/backend.public.yaml
+++ b/fleet/dst-dashboard/ingresses/backend.public.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dst-dashboard-backend-ingress
+  annotations:
+    traefik.ingress.kubernetes.io/router.middlewares: default-redirect-https@kubernetescrd
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  ingressClassName: traefik
+  tls:
+  - hosts:
+    - api.dashboard.lab.vac.dev
+    secretName: dashboard-backend-tls
+  rules:
+  - host: api.dashboard.lab.vac.dev
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: dst-dashboard-backend
+            port:
+              number: 8000

--- a/fleet/dst-dashboard/ingresses/fleet.yaml
+++ b/fleet/dst-dashboard/ingresses/fleet.yaml
@@ -1,0 +1,3 @@
+defaultNamespace: dst-dashboard
+dependsOn:
+  - name: vaclab-2-fleet-dst-dashboard-services

--- a/fleet/dst-dashboard/ingresses/frontend.public.yaml
+++ b/fleet/dst-dashboard/ingresses/frontend.public.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dst-dashboard-frontend-ingress
+  annotations:
+    traefik.ingress.kubernetes.io/router.middlewares: default-redirect-https@kubernetescrd
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  ingressClassName: traefik
+  tls:
+  - hosts:
+    - dashboard.lab.vac.dev
+    secretName: dashboard-frontend-tls
+  rules:
+  - host: dashboard.lab.vac.dev
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: dst-dashboard-frontend
+            port:
+              number: 80

--- a/fleet/dst-dashboard/mongodb/fleet.yaml
+++ b/fleet/dst-dashboard/mongodb/fleet.yaml
@@ -1,0 +1,1 @@
+defaultNamespace: dst-dashboard

--- a/fleet/dst-dashboard/mongodb/mongodb-prod.yaml
+++ b/fleet/dst-dashboard/mongodb/mongodb-prod.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mongodb-prod
+spec:
+  serviceName: mongodb-prod
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mongodb-prod
+  template:
+    metadata:
+      labels:
+        app: mongodb-prod
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - metal-01.he-eu-hel1.misc.vacdst
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "monitoring"
+          effect: "PreferNoSchedule"
+      containers:
+        - name: mongodb-prod
+          image: mongo:8
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 27017
+              name: mongodb-prod
+              protocol: TCP
+          env:
+            - name: MONGO_INITDB_ROOT_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: dst-mongo-prod-credentials
+                  key: username
+            - name: MONGO_INITDB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: dst-mongo-prod-credentials
+                  key: password
+          volumeMounts:
+            - name: mongo-data-prod
+              mountPath: /data/db
+      volumes:
+      - name: mongo-data-prod
+        persistentVolumeClaim:
+          claimName: dst-mongo-prod-pvc
+

--- a/fleet/dst-dashboard/mongodb/volumes.yaml
+++ b/fleet/dst-dashboard/mongodb/volumes.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dst-mongo-prod-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn-vaclab
+  resources:
+    requests:
+      storage: 100Gi

--- a/fleet/dst-dashboard/services/backend.svc.yaml
+++ b/fleet/dst-dashboard/services/backend.svc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dst-dashboard-backend
+spec:
+  selector:
+    app: dst-dashboard-backend
+  ports:
+  - protocol: TCP
+    port: 8000
+    targetPort: 8000
+  type: ClusterIP
+  clusterIP: None

--- a/fleet/dst-dashboard/services/fleet.yaml
+++ b/fleet/dst-dashboard/services/fleet.yaml
@@ -1,0 +1,4 @@
+defaultNamespace: dst-dashboard
+#dependsOn:
+#  - name: vaclab-2-fleet-dst-dashboard-backend
+#  - name: vaclab-2-fleet-dst-dashboard-frontend

--- a/fleet/dst-dashboard/services/frontend.svc.yaml
+++ b/fleet/dst-dashboard/services/frontend.svc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dst-dashboard-frontend
+spec:
+  selector:
+    app: dst-dashboard-frontend
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 80
+  type: ClusterIP

--- a/fleet/dst-dashboard/services/mongodb-prod.svc.yaml
+++ b/fleet/dst-dashboard/services/mongodb-prod.svc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongodb-prod
+spec:
+  type: ClusterIP
+  selector:
+    app: mongodb-prod
+  ports:
+    - name: mongodb-prod
+      protocol: TCP
+      port: 8021
+      targetPort: 27017

--- a/fleet/homepage/configmap.yaml
+++ b/fleet/homepage/configmap.yaml
@@ -87,31 +87,6 @@ data:
             namespace: victorialogs
             podSelector: >-
               app in (vlselect)
-    
-    - DST TOOLS:
-        - DST Dashboard:
-            icon: mdi-chart-line
-            href: https://dashboard.lab.vac.dev
-            description: Experiment results & visualizations
-            namespace: dst-dashboard
-            podSelector: >-
-              app in (dst-dashboard-frontend)
-
-        - DST Dashboard API:
-            icon: si-swagger
-            href: https://api.dashboard.lab.vac.dev/api/docs
-            description: DST Dashboard API documentation
-            namespace: dst-dashboard
-            podSelector: >-
-              app in (dst-dashboard-backend)
-
-        - DST Dashboard Admin:
-            icon: mdi-shield-key
-            href: https://api.dashboard.lab.vac.dev/admin/token
-            description: Create/Update/Delete Experiments & admin token
-            namespace: dst-dashboard
-            podSelector: >-
-              app in (dst-dashboard-backend)
 
   
   widgets.yaml: |

--- a/fleet/homepage/configmap.yaml
+++ b/fleet/homepage/configmap.yaml
@@ -87,6 +87,32 @@ data:
             namespace: victorialogs
             podSelector: >-
               app in (vlselect)
+    
+    - DST TOOLS:
+        - DST Dashboard:
+            icon: mdi-chart-line
+            href: https://dashboard.lab.vac.dev
+            description: Experiment results & visualizations
+            namespace: dst-dashboard
+            podSelector: >-
+              app in (dst-dashboard-frontend)
+
+        - DST Dashboard API:
+            icon: si-swagger
+            href: https://api.dashboard.lab.vac.dev/api/docs
+            description: DST Dashboard API documentation
+            namespace: dst-dashboard
+            podSelector: >-
+              app in (dst-dashboard-backend)
+
+        - DST Dashboard Admin:
+            icon: mdi-shield-key
+            href: https://api.dashboard.lab.vac.dev/admin/token
+            description: Create/Update/Delete Experiments & admin token
+            namespace: dst-dashboard
+            podSelector: >-
+              app in (dst-dashboard-backend)
+
   
   widgets.yaml: |
     - logo:

--- a/fleet/homepage/configmap.yaml
+++ b/fleet/homepage/configmap.yaml
@@ -108,7 +108,7 @@ data:
             href: https://api.dashboard.lab.vac.dev/admin/token
             description: Create/Update/Delete Experiments & admin token
             namespace: dst-dashboard
-            app dst-dashboard-backend
+            app: dst-dashboard-backend
 
   
   widgets.yaml: |

--- a/fleet/homepage/configmap.yaml
+++ b/fleet/homepage/configmap.yaml
@@ -87,6 +87,28 @@ data:
             namespace: victorialogs
             podSelector: >-
               app in (vlselect)
+    
+    - DST TOOLS:
+        - DST Dashboard:
+            icon: mdi-chart-line
+            href: https://dashboard.lab.vac.dev
+            description: Experiment results & visualizations
+            namespace: dst-dashboard
+            app: dst-dashboard-frontend
+
+        - DST Dashboard API:
+            icon: si-swagger
+            href: https://api.dashboard.lab.vac.dev/api/docs
+            description: DST Dashboard API documentation
+            namespace: dst-dashboard
+            app: dst-dashboard-backend
+
+        - DST Dashboard Admin:
+            icon: mdi-shield-key
+            href: https://api.dashboard.lab.vac.dev/admin/token
+            description: Create/Update/Delete Experiments & admin token
+            namespace: dst-dashboard
+            app dst-dashboard-backend
 
   
   widgets.yaml: |

--- a/fleet/homepage/deployment.yaml
+++ b/fleet/homepage/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: homepage
 spec:
   revisionHistoryLimit: 3
-  replicas: 2
+  replicas: 1
   strategy:
     type: RollingUpdate
   selector:
@@ -61,11 +61,11 @@ spec:
                 - ALL
           resources:
             requests:
-              cpu: "2"
-              memory: "512Mi"
-            limits:
               cpu: "4"
-              memory: "4Gi"
+              memory: "2Gi"
+            limits:
+              cpu: "8"
+              memory: "8Gi"
           volumeMounts:
             - mountPath: /app/config/custom.js
               name: homepage-config


### PR DESCRIPTION
## Context
This PR creates all fleet resources for the deployment of the DST dashboard ecosystem

## Changes
- Added fleet resources for DST dashboard backend,  frontend, mongodb, longhorn volume (with 2 replicas), services, ingresses, configmap
- Protected admin path with traefik auth forward to force authentik SSO
- Added DST dashboard, Admin UI and API reference to vaclab homepage
- Deployed everything on metal-01 node

## App URLs
- Public DST Dashboard: [https://dashboard.lab.vac.dev](https://dashboard.lab.vac.dev)
- Admin Page (token generation, Add/Update/Delete Experiments): [https://api.dashboard.lab.vac.dev/admin/token](https://api.dashboard.lab.vac.dev/admin/token) (require Authentication via keycloak)